### PR TITLE
Prevent warning: Invalid argument supplied for foreach

### DIFF
--- a/suppressblankaddress.php
+++ b/suppressblankaddress.php
@@ -114,6 +114,8 @@ function suppressblankaddress_civicrm_tokens(&$tokens) {
 }
 
 function suppressblankaddress_civicrm_tokenValues( &$values, $cids, $job = null, $tokens = array(), $context = null ) {
+  if (is_null($cids) ) { $cids = array(); }
+  
   foreach($cids as $id){
     $params   = array('contact_id' => $id);
     try {


### PR DESCRIPTION
In some cases, CiviCRM triggers the `tokenValues` hook with the **$cids** set to null. With this patch, we prevent a *PHP Warning:  Invalid argument supplied for foreach()*.